### PR TITLE
Only display errors span into the label if isDiplayingErrors is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ You can use any plug-in control and bind them to ember-light-form fields as illu
 
 The available attributes are:
 
-* `field.label`: the field label
 * `field.value`: the value of the field attribute (here `author`)
-* `field.update`: the action that updates of the field attribute (here `author`)
 * `field.controlId`: the id of the control (match the label `for` attribute)
+* `field.errors`: the errors of the field attribute
+* `field.update`: the action that updates of the field attribute (here `author`)
 

--- a/addon/templates/components/light-field.hbs
+++ b/addon/templates/components/light-field.hbs
@@ -1,6 +1,6 @@
 {{#if label}}
   <label for={{controlId}} class="light-field__label">
-    {{label}} <span class="light-field__errors">({{errors}})</span>
+    {{label}} {{#if isDisplayingErrors}}<span class="light-field__errors">({{errors}})</span>{{/if}}
   </label>
 {{/if}}
 
@@ -9,6 +9,7 @@
     (hash
       controlId=controlId
       value=(get model fieldName)
+      errors=errors
       enterEditMode=(action 'enterEditMode')
       leaveEditMode=(action 'leaveEditMode')
       update=(action 'update')


### PR DESCRIPTION
- This is to make sure that we do not rely on some CSS to conditionally displaying it.
- the `errors` are yielded to enable more customization 
