### PR TITLE
Update light-field.hbs

### DIFF
--- a/addon/templates/components/light-field.hbs
+++ b/addon/templates/components/light-field.hbs
@@ -1,26 +1,16 @@
 {{#if (has-block)}}
-  {{#component component
-    field=(hash
-      label=label
-      control=(component control
-        id=controlId
-        value=(get model fieldName)
-        onfocus=(action 'enterEditMode')
-        onblur=(action 'leaveEditMode')
-        update=(action 'update')
-      )
-      controlId=controlId
-      value=(get model fieldName)
-      errors=errors
-      isDisplayingErrors=isDisplayingErrors
-      enterEditMode=(action 'enterEditMode')
-      leaveEditMode=(action 'leaveEditMode')
-      update=(action 'update')
-    )
-  }}
-    {{yield
-      (hash
-        id=controlId
+  {{yield (hash
+    component=(component component
+      field=(hash
+        label=label
+        control=(component control
+          id=controlId
+          value=(get model fieldName)
+          onfocus=(action 'enterEditMode')
+          onblur=(action 'leaveEditMode')
+          update=(action 'update')
+        )
+        controlId=controlId
         value=(get model fieldName)
         errors=errors
         isDisplayingErrors=isDisplayingErrors
@@ -28,8 +18,23 @@
         leaveEditMode=(action 'leaveEditMode')
         update=(action 'update')
       )
-    }}
-  {{/component}}
+    )
+    control=(component control
+      id=controlId
+      value=(get model fieldName)
+      onfocus=(action 'enterEditMode')
+      onblur=(action 'leaveEditMode')
+      update=(action 'update')
+    )
+    label=label
+    controlId=controlId
+    value=(get model fieldName)
+    errors=errors
+    isDisplayingErrors=isDisplayingErrors
+    enterEditMode=(action 'enterEditMode')
+    leaveEditMode=(action 'leaveEditMode')
+    update=(action 'update')
+  )}}
 {{else}}
   {{component component
     field=(hash


### PR DESCRIPTION
Removed the wrapping component and passed it as hash parameter to be used within block.

This allow such block to customize the component yields without redefining all the parameters : 
```
      {{#f.field "organizationDomain" label="Organization Domain" as |Field|}}
        {{#component Field.component as |FieldComponent|}}
          {{#FieldComponent.message}}
            Enter the domain name of the email address (for example “prospect.io”).
          {{/FieldComponent.message}}
        {{/component}}
      {{/f.field}}
```