### PR TITLE
add a ‘fields-for’ field component

### DIFF
--- a/addon/components/fields-for.js
+++ b/addon/components/fields-for.js
@@ -1,0 +1,11 @@
+import Form from 'ember-light-form/components/light-form';
+
+const FieldsFor = Form.extend({
+  tagName: 'div',
+});
+
+FieldsFor.reopenClass({
+  positionalParams: ['model']
+});
+
+export default FieldsFor;

--- a/addon/templates/components/light-form.hbs
+++ b/addon/templates/components/light-form.hbs
@@ -22,6 +22,7 @@
   time=(component 'one-way-time' classNames='light-input')
   url=(component 'one-way-url' classNames='light-input')
   week=(component 'one-way-week' classNames='light-input')
+  fields-for=(component 'fields-for' defaultFieldComponent=defaultFieldComponent isValidating=isValidating classNames=classNames)
   isRunning=isRunning
   submit=(action "submit")
 )}}

--- a/app/components/fields-for.js
+++ b/app/components/fields-for.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-light-form/components/fields-for';


### PR DESCRIPTION
It adds the possibility to include in a form some fields that depends on a model other than the one of the main form. The validation state of the nested form(s) is shared with the main form, so that the display of errors is coherent.

``` handlebars
{{#light-form model1 action=(action "onSubmit") as |mainForm| }}
    {{#mainForm.fields-for model2 as |subForm|}}
        {{#subForm.field "attributeName"
            as |Field|
        }}
            ....
        {{/Form.field}}
    {{/mainForm.fields-for}}
{{/light-form}}
```