### PR TITLE
[fix] pass the right default template to fields-for

### DIFF
--- a/addon/templates/components/light-form.hbs
+++ b/addon/templates/components/light-form.hbs
@@ -22,7 +22,7 @@
   time=(component 'one-way-time' classNames='light-input')
   url=(component 'one-way-url' classNames='light-input')
   week=(component 'one-way-week' classNames='light-input')
-  fields-for=(component 'fields-for' defaultFieldComponent=defaultFieldComponent isValidating=isValidating classNames=classNames)
+  fields-for=(component 'fields-for' defaultFieldTemplate=defaultFieldTemplate isValidating=isValidating classNames=classNames)
   isRunning=isRunning
   submit=(action "submit")
 )}}


### PR DESCRIPTION
It fixes a bug in `fields-for` introduced by the last changes