### PR TITLE
Make possible to display warning messages

### DIFF
--- a/addon/components/light-field.js
+++ b/addon/components/light-field.js
@@ -17,6 +17,9 @@ const Field = Component.extend({
   errors: null,
   hasErrors: notEmpty('errors'),
 
+  warnings: null,
+  hasWarnings: notEmpty('warnings'),
+
   isDisplayingErrors: computed(
     'hasErrors',
     'isErrorDisplayForced',
@@ -47,6 +50,7 @@ const Field = Component.extend({
     this._super(...arguments);
 
     this._bindModelErrors();
+    this._bindModelWarnings();
   },
 
   didUpdateAttrs() {
@@ -65,6 +69,12 @@ const Field = Component.extend({
   _bindModelErrors() {
     defineProperty(this, 'errors', oneWay(
       `model.${Configuration.errorMessagesPathFor(get(this, 'fieldName'))}`
+    ));
+  },
+
+  _bindModelWarnings() {
+    defineProperty(this, 'warnings', oneWay(
+      `model.${Configuration.warningMessagesPathFor(get(this, 'fieldName'))}`
     ));
   },
 

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -4,6 +4,8 @@ import { typeOf } from '@ember/utils';
 const DEFAULTS = {
   isValidPath: 'isValid',
   errorMessagePath: 'error.FIELD_NAME.validation',
+  hasWarningPath: 'hasWarnings',
+  warningMessagePath: 'warning.FIELD_NAME.validation',
   defaultFieldTemplate: 'light-field'
 };
 
@@ -17,7 +19,9 @@ const DEFAULTS = {
   // config/environment.js
   ENV['ember-light-form'] = {
     isValidPath: 'validations.isValid',
-    errorMessagePath: 'validations.attrs.FIELD_NAME.messages'
+    errorMessagePath: 'validations.attrs.FIELD_NAME.messages',
+    hasWarnings: validations.hasWarnings,
+    warningMessagePath: validations.attrs.FIELD_NAME.warningMessages
   };
   ```
 
@@ -63,8 +67,37 @@ export default {
   */
   errorMessagePath: DEFAULTS.errorMessagePath,
 
+  /**
+    The hasWarningsPath of the application as configured in `config/environment.js`.
+
+    @property hasWarningsPath
+    @readOnly
+    @static
+    @type String
+    @default ''
+    @public
+  */
+  hasWarningsPath: DEFAULTS.hasWarningsPath,
+
+  /**
+    The warningMessagePath of the application as configured in `config/environment.js`.
+
+    @property warningMessagePath
+    @readOnly
+    @static
+    @type String
+    @default ''
+    @public
+  */
+  warningMessagePath: DEFAULTS.warningMessagePath,
+
+
   errorMessagesPathFor(fieldName) {
     return this.errorMessagePath.replace('FIELD_NAME', fieldName);
+  },
+
+  warningMessagesPathFor(fieldName) {
+    return this.warningMessagePath.replace('FIELD_NAME', fieldName);
   },
 
   load(config) {

--- a/addon/templates/components/light-field.hbs
+++ b/addon/templates/components/light-field.hbs
@@ -1,10 +1,11 @@
 {{#if (has-block)}}
-  {{yield 
+  {{yield
     (hash
       label=label
       controlId=controlId
       value=(get model fieldName)
       errors=errors
+      warnings=warnings
       isDisplayingErrors=isDisplayingErrors
       enterEditMode=(action 'enterEditMode')
       leaveEditMode=(action 'leaveEditMode')
@@ -13,8 +14,8 @@
   }}
 {{else}}
   <label for={{controlId}}>{{label}}</label>
-  
-  {{component control 
+
+  {{component control
     id=controlId
     value=(get model fieldName)
     onfocus=(action 'enterEditMode')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-light-form",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Extensible Ember Form components - Take control over your form controls.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Add support for displaying the warning messages of a field. Warning messages are messages from validators that do not prevent the form to be submitted if they are invalid. This allow to do such things: 
![Capture d’écran 2020-05-15 à 14 45 53](https://user-images.githubusercontent.com/22883304/82052137-6f628600-96bb-11ea-9652-eb49a9bd1e7f.png)
